### PR TITLE
vortex: Generator: Add token_callback

### DIFF
--- a/vortex/model/generation.py
+++ b/vortex/model/generation.py
@@ -34,6 +34,7 @@ class Generator:
         skip_special_tokens=False,
         stop_at_eos=True,
         max_seqlen=None,
+        token_callback=lambda i: None,
     ):
         if isinstance(self.tokenizer.eos, int):
             eos_token_ids = torch.LongTensor([self.tokenizer.eos]).to(device)
@@ -123,6 +124,8 @@ class Generator:
                     x,
                     inference_params_dict=inference_params_dict_out,
                 )
+
+            token_callback(i)
 
             last_logits = logits[:, -1]
             if print_generation and verbose and batch_size == 1:


### PR DESCRIPTION
This allows us to implement graceful timeout on NIM side without spawning additional threads to enforce the time limits.

We use it like this:

```
def run_generate(...):
    ...

    def token_callback(i):
        if monotonic() > deadline:
            raise TimeoutError(f"Timed out on {i}th token out of {num_tokens} requested. Allowed to run for {timeout_s} seconds.")

    with torch.inference_mode():
        g = Generator(m, tokenizer, top_k=top_k, top_p=top_p, temperature=temperature)
        tokens, logits = g.generate(
            num_tokens=num_tokens,
            ...
            token_callback=token_callback,
        )
```

(cherry picked from commit b5c61c09e8f776054c179c6fae0ed88b5b3876f1)