### PR TITLE
Make it possible to reuse test logic in NIM benchmarking

### DIFF
--- a/test/accuracy_test_generation.py
+++ b/test/accuracy_test_generation.py
@@ -36,6 +36,8 @@ def generate_and_score(sequences, generator, tokenizer, args, generations_per_pr
     """
     Prompt with first half, generate and score on 2nd half
     """
+    import torch
+
     scores = []
     prompts = []
     targets = []


### PR DESCRIPTION
NIM accuracy benchmarking run via http API, so the environment is different from the tests that we run in vortex tree (e.g. no torch is installed.) We would still like to reuse some logic (`mid_point_split` in particular) from tests instead of copying the code to a separate benchmarking scripts. For that, factor out `mid_point_split` call, and hide most imports to call sites, which makes torch and vortex model itself a soft dependency in the test.