### PR TITLE
vortex: Fixup for TE's global gemm workspace

### DIFF
--- a/vortex/model/utils.py
+++ b/vortex/model/utils.py
@@ -139,6 +139,25 @@ def fixup_fp8_extra_states(module):
         with patch('torch.load', new=overriden_load):
             module.set_extra_state(module.get_extra_state())
 
+def fixup_te_workspace():
+    """TE uses single workspace tensor for all calls, disregarding that inputs
+    may be on separate GPUs. This patches TE's Linear module to use per-device
+    workspaces."""
+    from functools import lru_cache
+    @lru_cache
+    def te_cublas_get_workspace_per_device(device):
+        log.info(f"Fixup applied: Allocating cublas workspace for {device=}")
+        import transformer_engine.pytorch.module.base as tebase
+        with torch.cuda.device(device):
+            tebase._cublas_workspace = None # Force get_workspace() to reallocate tensor
+            return tebase.get_workspace()
+
+    def get_workspace():
+        return te_cublas_get_workspace_per_device(torch.cuda.current_device())
+
+    import transformer_engine.pytorch.module.linear as telinear
+    telinear.get_workspace = get_workspace
+
 def get_init_from_string(init_str):
     if type(init_str) == str:
         if init_str == "torch.nn.init.zeros_":


### PR DESCRIPTION
Fixes errors like this (reproducible only with FP8=off):

```
[01/25/25 02:02:55] INFO     StripedHyena - INFO - Adjusting Wqkv for column split (permuting rows)                                                                                                      model.py:963
Traceback (most recent call last):
  File "/workdir/test/accuracy_test_forward.py", line 107, in <module>
    test_dna_model(m)
  File "/workdir/test/accuracy_test_forward.py", line 43, in test_dna_model
    output1, _ = model.forward(input_ids)
  File "/workdir/vortex/model/model.py", line 760, in forward
    x, inference_params_dict_out = self.stateless_forward(
  File "/workdir/vortex/model/model.py", line 850, in stateless_forward
    x, _ = block(x, inference_params=None, padding_mask=padding_mask)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1736, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1747, in _call_impl
    return forward_call(*args, **kwargs)
  File "/workdir/vortex/model/model.py", line 581, in forward
    z = self.proj_norm(u)
  File "/workdir/vortex/model/model.py", line 537, in proj_norm
    projected = self.projections(normalized)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1736, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1747, in _call_impl
    return forward_call(*args, **kwargs)
  File "/workdir/vortex/model/layers.py", line 81, in forward
    out = super().forward(x)
  File "/usr/local/lib/python3.10/dist-packages/torch/_dynamo/eval_frame.py", line 632, in _fn
    return fn(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/transformer_engine/pytorch/module/linear.py", line 1019, in forward
    out = linear_fn(*args)
  File "/usr/local/lib/python3.10/dist-packages/transformer_engine/pytorch/module/linear.py", line 274, in forward
    _ = gemm(
  File "/usr/local/lib/python3.10/dist-packages/transformer_engine/pytorch/cpp_extensions/gemm.py", line 303, in gemm
    _ = fn(*args)
  File "/usr/local/lib/python3.10/dist-packages/torch/_ops.py", line 1116, in __call__
    return self._op(*args, **(kwargs or {}))
RuntimeError: /tmp/pip-req-build-kk4q3ge_/transformer_engine/common/gemm/cublaslt_gemm.cu:261 in function cublas_gemm: cuBLAS Error: an internal operation failed
```