### PR TITLE
vortex: Add Dockerfile-based run files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
 *
-!requirements.txt
+!pyproject.toml
 !vortex/ops

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*
+!requirements.txt
+!vortex/ops

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
-# To run 40b generation sample: `./run`.
+from nvcr.io/nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04 as base
+run apt-get update && apt-get install -y python3-pip git && rm -rf /var/lib/apt/lists/*
 
-# To run 7b generation sample: `sz=7 ./run`.
-
-# To run tests: `./run ./run_tests`.
-
-# To interactively execute commands in docker environment: `./run bash`.
-
-from nvcr.io/nvidia/pytorch:24.10-py3 as base
-arg REQUIREMENTS=requirements.txt.frozen
+arg REQUIREMENTS=requirements.txt
 copy ${REQUIREMENTS} .
 run --mount=type=cache,target=/root/.cache \
     pip install -r ${REQUIREMENTS}
+
+copy vortex/ops /usr/src/vortex-ops
+run --mount=type=cache,target=/root/.cache \
+    cd /usr/src/vortex-ops/attn && MAX_JOBS=32 pip install -v -e  . --no-build-isolation
+
 workdir /workdir

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,17 @@
 from nvcr.io/nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04 as base
-run apt-get update && apt-get install -y python3-pip git && rm -rf /var/lib/apt/lists/*
+run apt-get update && apt-get install -y python3-pip python3-tomli && rm -rf /var/lib/apt/lists/*
 
-arg REQUIREMENTS=requirements.txt
-copy ${REQUIREMENTS} .
+# Extract dependencies from pyproject: can't use pip-tools' pip-compile as it
+# requires whole tree to be copied to Docker context, which makes it impossible
+# to develop in docker envrionment.
+copy pyproject.toml .
+run python3 -c 'import tomli;\
+                p = tomli.load(open("pyproject.toml", "rb"))["project"];\
+                print("\n".join(p["dependencies"] + p["optional-dependencies"]["special"]))'\
+    > requirements.txt
 # Must install torch first, as transformer engine build process will need it
 run pip install `cat requirements.txt | grep ^torch`
-run pip install -r ${REQUIREMENTS}
+run pip install -r requirements.txt
 
 copy vortex/ops /usr/src/vortex-ops
 run cd /usr/src/vortex-ops/attn && MAX_JOBS=32 pip install -v -e  . --no-build-isolation

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,11 @@ run apt-get update && apt-get install -y python3-pip git && rm -rf /var/lib/apt/
 
 arg REQUIREMENTS=requirements.txt
 copy ${REQUIREMENTS} .
-run --mount=type=cache,target=/root/.cache \
-    pip install -r ${REQUIREMENTS}
+# Must install torch first, as transformer engine build process will need it
+run pip install `cat requirements.txt | grep ^torch`
+run pip install -r ${REQUIREMENTS}
 
 copy vortex/ops /usr/src/vortex-ops
-run --mount=type=cache,target=/root/.cache \
-    cd /usr/src/vortex-ops/attn && MAX_JOBS=32 pip install -v -e  . --no-build-isolation
+run cd /usr/src/vortex-ops/attn && MAX_JOBS=32 pip install -v -e  . --no-build-isolation
 
 workdir /workdir

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 from nvcr.io/nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04 as base
-run apt-get update && apt-get install -y python3-pip python3-tomli && rm -rf /var/lib/apt/lists/*
+run apt-get update && apt-get install -y git python3-pip python3-tomli && rm -rf /var/lib/apt/lists/*
 
 # Extract dependencies from pyproject: can't use pip-tools' pip-compile as it
 # requires whole tree to be copied to Docker context, which makes it impossible

--- a/README.md
+++ b/README.md
@@ -16,6 +16,22 @@ There are two main ways to interface with `vortex`:
 1. Use `vortex` as the inference engine for pre-trained multi-hybrids such as [Evo 2 40B](configs/evo2-40b-1m.yml). In this case, we recommend installing `vortex` in a new environment (see below).
 2. Import from `vortex` specific classes, kernels or utilities to work with custom convolutional multi-hybrids. For example,sourcing utilities from `hyena_ops.interface`.
 
+## Running in a Docker Environment
+
+Docker is one of the easiest ways to get started with Vortex (and Evo 2). The
+Docker environment does not depend on the currently installed CUDA version and
+ensures that major dependencies (such as PyTorch and Transformer Engine) are
+pinned to specific versions, which is beneficial for reproducibility.
+
+To run Evo 2 40B generation sample, simply run `./run`.
+
+To run Evo 2 7B generation sample: `sz=7 ./run`.
+
+To run tests: `./run ./run_tests`.
+
+To interactively execute commands in docker environment: `./run bash`.
+
+For non-Docker setup, please follow instructions below.
 
 ## 1. Quick install for vortex ops
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ description = "Reference implementation of operators for deep signal processing 
 readme = "README.md"
 license = {file = "LICENSE"}
 authors = [{ name = "Michael Poli"}]
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 dependencies = [
     "torch==2.5.1",
     "rich==13.9.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,13 @@ dependencies = [
     "setuptools",
 ]
 
+[project.optional-dependencies]
+# Technically, these are required dependencies, but those use legacy builds and
+# UV cannot handle them in the most general case. See
+# https://github.com/astral-sh/uv/issues/7405
+# Instead, those are handled specially via Makefile and Dockerfile
+special = ["transformer_engine[pytorch]==1.13.0"]
+
 [tool.black]
 line-length = 119
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,9 @@
-torch>=2.6.0
+torch==2.5.1
+transformer_engine[pytorch]==1.13.0
+cmake
+ninja
+pyyaml
+tqdm
 rich
 ruff
 pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,1 @@
-torch==2.5.1
-transformer_engine[pytorch]==1.13.0
-cmake
-ninja
-pyyaml
-tqdm
-rich
-ruff
-pre-commit
+# Don't use this file: dependencies are now in pyproject.toml

--- a/run
+++ b/run
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -e -o pipefail
+
+cd "$(dirname "$0")"
+
+default_cmd="./run_generate"
+
+run_args=(-it --rm
+    $DOCKER_RUN_ARGS
+    --entrypoint "" # skip image banners
+    --gpus=all
+    --ipc=host --ulimit memlock=-1 --ulimit stack=67108864
+
+    # Make docker's user id same as host machine user id
+    -u $(id -u):$(id -g) -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro
+
+    -v $PWD:$PWD
+    -v $PWD/.home:$HOME # so that ~/.local and ~/.cache are project-specific
+    -w $PWD
+
+    -e sz -e cfg -e ckpt
+    vortex
+    ${@:-$default_cmd}
+)
+
+mkdir -p .home
+
+docker build -t vortex $DOCKER_BUILD_ARGS .
+docker run "${run_args[@]}"

--- a/run
+++ b/run
@@ -3,6 +3,8 @@ set -e -o pipefail
 
 cd "$(dirname "$0")"
 
+git submodule update --init --recursive
+
 default_cmd="./run_generate"
 
 run_args=(-it --rm

--- a/run
+++ b/run
@@ -20,6 +20,7 @@ run_args=(-it --rm
     # Below volume-mount is useful for developing in docker env, but may harm
     # reproducibility. Therefore, commented-out by default.
     # -v $PWD/.home:$HOME # so that ~/.local and ~/.cache are project-specific
+    -v /tmp:$HOME/.triton # triton library needs this to be writable for caches
     -w $PWD
 
     -e sz -e cfg -e ckpt

--- a/run
+++ b/run
@@ -17,7 +17,9 @@ run_args=(-it --rm
     -u $(id -u):$(id -g) -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro
 
     -v $PWD:$PWD
-    -v $PWD/.home:$HOME # so that ~/.local and ~/.cache are project-specific
+    # Below volume-mount is useful for developing in docker env, but may harm
+    # reproducibility. Therefore, commented-out by default.
+    # -v $PWD/.home:$HOME # so that ~/.local and ~/.cache are project-specific
     -w $PWD
 
     -e sz -e cfg -e ckpt

--- a/run_generate
+++ b/run_generate
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e -o pipefail
+
+if [ "$sz" == "7" ]; then
+    cfg=${cfg:-configs/shc-evo2-7b-8k-2T-v2-interleave.yml}
+    ckpt=${ckpt:-iter_500000.pt}
+else
+    cfg=${cfg:-configs/shc-evo2-40b-8k-11T-v2.yml}
+    ckpt=${ckpt:-iter_504000.pt}
+fi
+
+if [ -e "$ckpt" ]; then
+    ckpt="--checkpoint_path $ckpt"
+else
+    echo Using random weights
+    ckpt="--dry_run"
+fi
+
+python3 generate.py $ckpt --config_path $cfg --debug

--- a/run_generate
+++ b/run_generate
@@ -11,11 +11,4 @@ else
     ckpt=${ckpt:-evo2_40b.pt}
 fi
 
-if [ -e "$ckpt" ]; then
-    ckpt="--checkpoint_path $ckpt"
-else
-    echo Using random weights
-    ckpt="--dry_run"
-fi
-
-python3 generate.py $ckpt --config_path $cfg --debug
+python3 generate.py --checkpoint_path $ckpt --config_path $cfg --debug

--- a/run_generate
+++ b/run_generate
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 set -e -o pipefail
 
+cd "$(dirname "$0")"
+
 if [ "$sz" == "7" ]; then
-    cfg=${cfg:-configs/shc-evo2-7b-8k-2T-v2-interleave.yml}
-    ckpt=${ckpt:-iter_500000.pt}
+    cfg=${cfg:-configs/evo2-7b-1m.yml}
+    ckpt=${ckpt:-evo2_7b.pt}
 else
-    cfg=${cfg:-configs/shc-evo2-40b-8k-11T-v2.yml}
-    ckpt=${ckpt:-iter_504000.pt}
+    cfg=${cfg:-configs/evo2-40b-1m.yml}
+    ckpt=${ckpt:-evo2_40b.pt}
 fi
 
 if [ -e "$ckpt" ]; then

--- a/run_tests
+++ b/run_tests
@@ -13,5 +13,5 @@ fi
 
 export PYTHONPATH=.
 
-python3 test/accuracy_test_forward.py    --config_path $cfg --checkpoint_path $ckpt
-python3 test/accuracy_test_generation.py --config_path $cfg --checkpoint_path $ckpt
+python3 test/test_evo2_forward.py    --config_path $cfg --checkpoint_path $ckpt
+python3 test/test_evo2_generation.py --config_path $cfg --checkpoint_path $ckpt

--- a/run_tests
+++ b/run_tests
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e -o pipefail
+
+cd "$(dirname "$0")"
+
+if [ "$sz" == "7" ]; then
+    cfg=${cfg:-configs/shc-evo2-7b-8k-2T-v2-interleave.yml}
+    ckpt=${ckpt:-iter_500000.pt}
+else
+    cfg=${cfg:-configs/shc-evo2-40b-8k-11T-v2.yml}
+    ckpt=${ckpt:-iter_504000.pt}
+fi
+
+export PYTHONPATH=.
+
+python3 test/accuracy_test_forward.py    --config_path $cfg --checkpoint_path $ckpt
+python3 test/accuracy_test_generation.py --config_path $cfg --checkpoint_path $ckpt

--- a/run_tests
+++ b/run_tests
@@ -4,11 +4,11 @@ set -e -o pipefail
 cd "$(dirname "$0")"
 
 if [ "$sz" == "7" ]; then
-    cfg=${cfg:-configs/shc-evo2-7b-8k-2T-v2-interleave.yml}
-    ckpt=${ckpt:-iter_500000.pt}
+    cfg=${cfg:-configs/evo2-7b-1m.yml}
+    ckpt=${ckpt:-evo2_7b.pt}
 else
-    cfg=${cfg:-configs/shc-evo2-40b-8k-11T-v2.yml}
-    ckpt=${ckpt:-iter_504000.pt}
+    cfg=${cfg:-configs/evo2-40b-1m.yml}
+    ckpt=${ckpt:-evo2_40b.pt}
 fi
 
 export PYTHONPATH=.

--- a/vortex/ops/attn/setup.py
+++ b/vortex/ops/attn/setup.py
@@ -230,7 +230,7 @@ setup(
             "bdist_wheel": CachedWheelsCommand,
         }
     ),
-    python_requires=">=3.11",
+    python_requires=">=3.10",
     install_requires=[
         "torch",
         "einops",


### PR DESCRIPTION
- Use cuda image that I mostly tested with

- Freeze most important requirements for better reproducibility

- Switch to new naming for checkpoints and configs in run_generate and run_tests.

- Also, this pull request partially solves https://github.com/Zymrael/vortex/issues/46 . To solve issue completely, we just need to remove `setup.py` (making sure that evo2 repo doesn't actually depend on it.)