### PR TITLE
vortex: Dockerfile: Adjust after optional-dependencies removal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ run apt-get update && apt-get install -y git python3-pip python3-tomli && rm -rf
 copy pyproject.toml .
 run python3 -c 'import tomli;\
                 p = tomli.load(open("pyproject.toml", "rb"))["project"];\
-                print("\n".join(p["dependencies"] + p["optional-dependencies"]["special"]))'\
+                print("\n".join(p["dependencies"]))'\
     > requirements.txt
 # Must install torch first, as transformer engine build process will need it
 run pip install `cat requirements.txt | grep ^torch`


### PR DESCRIPTION
`optional-dependencies.special` was a workaround is no longer there since commit e3f4e5cb72bf0aef7e1ad00f7da2ff06bd6aa457.

Fixes following issue

```
    0.428 Traceback (most recent call last):
    0.428   File "<string>", line 1, in <module>
    0.428 KeyError: 'optional-dependencies'
```