### PR TITLE
vortex: Fix FP8 extra states (second attempt)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "torch>=2.6.0",
+    "torch>=2.5.0,<=2.6.1",
     "setuptools>=42",
     "wheel",
     "cmake",
@@ -18,7 +18,7 @@ readme = "README.md"
 authors = [{ name = "Michael Poli" }]
 requires-python = ">=3.10"
 dependencies = [
-    "torch>=2.6.0",
+    "torch>=2.5.1,<=2.6.1",
     "transformer_engine[pytorch]==1.13.0",
     "numpy",
     "einops==0.8.0",

--- a/test/test_evo2_generation.py
+++ b/test/test_evo2_generation.py
@@ -65,7 +65,6 @@ def generate_and_score(*, sequences, model, tokenizer, args, generations_per_pro
                 device=device,
                 verbose=1,
                 cached_generation=args.cached_generation,
-                force_prompt_threshold=5000,
             )
 
             decoded_seq = ret.sequences[0]

--- a/vortex/model/generation.py
+++ b/vortex/model/generation.py
@@ -285,7 +285,7 @@ def generate(
     top_p: float = 1.0,
     batched: bool = True,
     prepend_bos: bool = False,
-    force_prompt_threshold: int = 1000,
+    force_prompt_threshold: int = 3000,
     cached_generation: bool = True,
     verbose: int = 1,
     device: str = "cuda:0",


### PR DESCRIPTION
- The issue results in a crash only in some combinations of certain GPU interconnect and certain CPUs.

- In other cases, the issue only reproducible in rare cases, or never.

- The issue was initially fixed by fixing Transformer Engine code, but later converted to patching TE module from Evo 2 code (to untangle Evo 2 release and potential new TE release). Since conversion, the fixup stopped working, but got unnoticed since the issue is hard to reproduce unless using certain HW combination.

- To make sure fixup actually applied, I added some asserts as well.