### PR TITLE
Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,4 +90,4 @@ format:
 	ruff check --fix .
 	black -l 120 .
 
-rebuild: clean setup 
+rebuild: clean setup-full


### PR DESCRIPTION
Addresses two pieces of the Makefile.

First, a fix for https://github.com/Zymrael/vortex/issues/51. Instead of hardcoding `CUDA_PATH` and related variables before attempting to detect the `CUDA_PATH`, moved the default `CUDA_PATH` into the `CUDA_PATH` detection conditional. Then, set the renaming variables. This way differing CUDA paths in other environments aren't overwritten.

Second, updated `make rebuild` to call `setup-full` rather than `setup`, as `setup` was previously removed.