### PR TITLE
packaging: keep vtx wheels pure-Python (drop *.so from MANIFEST.in)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 recursive-include vortex *.py
-recursive-include vortex *.cpp *.cu *.h *.hpp *.cuh *.so
+recursive-include vortex *.cpp *.cu *.h *.hpp *.cuh
 recursive-include vortex/ops/attn/csrc/flash_attn *.cpp *.cu *.hpp
 recursive-include cutlass/include *.h
 include LICENSE


### PR DESCRIPTION
## What
Drop `*.so` from the `recursive-include vortex` line in `MANIFEST.in`.

## Why
That glob sweeps any compiled extension sitting in the build tree into the sdist/wheel. The top-level build is pure-Python (no `[build-system]` ext modules), so the result ships as `py3-none-any` (purelib) while actually embedding platform-specific CUDA binaries. The published **1.0.7** and **1.0.8** wheels each carry stray `flash_attn_2_cuda.*.so` files picked up this way.

`vtx` is pure-Python: the HC{S,M,L} inference kernels are Triton (JIT-compiled at runtime) and flash-attn / Transformer Engine are installed by the user per the README, so no `.so` belongs in the wheel. C/CUDA *sources* (`*.cpp`, `*.cu`, …) are retained for the local build path.

Packaging hygiene ahead of the **1.1.0** release that ships the opt-in HC{S,M,L} Triton kernels contributed by @AlphaKhaw (#77).

## Verify
```
python -m build
unzip -l dist/vtx-1.1.0-py3-none-any.whl | grep -E '\.so$'   # expect: no matches
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
