### PR TITLE
Fix ops path in Makefile: hyenax -> hyena_x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,11 +63,11 @@ setup-full: submodules
 
 setup-vortex-ops: submodules _check_env_enabled _setup_missing_env
 	pip install ninja cmake pybind11 numpy psutil
-	cd vortex/ops/hyenax && pip install -e .
+	cd vortex/ops/hyena_x && pip install -e .
 	pip install -e . --config-settings=build-script=local_setup.py
 
 setup-vortex-ops-hyenax: _check_env_enabled _setup_missing_env
-	cd vortex/ops/hyenax && pip install -e .
+	cd vortex/ops/hyena_x && pip install -e .
 
 submodules:
 	git submodule update --init --recursive


### PR DESCRIPTION
`make setup-vortex-ops` fails on a fresh clone because the Makefile points at `vortex/ops/hyenax`, but the directory is `vortex/ops/hyena_x`.

```
cd vortex/ops/hyenax && pip install -e .
/bin/sh: line 0: cd: vortex/ops/hyenax: No such file or directory
make: *** [setup-vortex-ops] Error 1
```

The same path appears in the `setup-vortex-ops-hyenax` target on line 70. This corrects both.

I left the target name itself unchanged to avoid breaking anyone already invoking it.

Verified `make setup-vortex-ops` proceeds past the ops build after this change. Reproduced on macOS.

Fixes #74