### PR TITLE
model: raise on multi-token input in HyenaCascade.sequential_forward

### DIFF
--- a/vortex/model/model.py
+++ b/vortex/model/model.py
@@ -329,6 +329,16 @@ class HyenaCascade(nn.Module):
         if self.data_dtype is None:
             self.data_dtype = u.dtype
 
+        if len(u.shape) > 2 and u.shape[1] > 1:
+            raise ValueError(
+                "HyenaCascade.sequential_forward received a multi-token input "
+                f"(seqlen={u.shape[1]}) after prefill, but chunk forward with "
+                "initial state is not implemented. Previously this input was "
+                "silently truncated to its last token (`u = u[:, -1]`), "
+                f"discarding {u.shape[1] - 1} token(s), returning a wrong "
+                "output for the surviving position, and corrupting the "
+                "recurrent/conv state for all subsequent tokens."
+            )
         if len(u.shape) > 2:
             u = u[:, -1]
 


### PR DESCRIPTION
Fixes #81.

## What

`HyenaCascade.sequential_forward` now raises a `ValueError` on multi-token input (seqlen > 1) instead of silently truncating to `u = u[:, -1]`.

## Why

After prefill, `HyenaCascade.forward` routes every call to `sequential_forward`. Passing several tokens at once (e.g. a chunk/block forward with initial state, as speculative-decoding verification requires) used to silently discard all but the last token: the dropped tokens had zero effect on output and state, the surviving position was computed with a wrong conv/recurrent window, and the layer state advanced by one token instead of `seqlen` — with no error and no warning, corrupting all subsequent decode steps. #81 has a self-contained random-weight reproduction (CPU, ~1 s).

A correct chunk forward is a real feature; until it exists, failing loudly turns a silent correctness bug into an explicit, debuggable error.

## Why this is safe

No first-party flow can trigger the raise: vortex's own `Generator` feeds one token per decode step (`x = x[:, -1:]`, `vortex/model/generation.py` L169) and prefill goes through `parallel_forward`. The new branch only activates for seqlen > 1, which previously always produced wrong results.

## Test

- The repro from #81 (stepwise single-token reference + one 4-token call) now raises with a clear message at the multi-token call; the single-token stepping path runs unchanged.
